### PR TITLE
Add Resource::Rusage class and ru_utime method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ end
     ru = getrusage(RUSAGE_SELF)      #=> {:ru_utime=>0.008506, :ru_stime=>0.008506, :ru_maxrss=>2512, :ru_ixrss=>0, :ru_idrss=>0, :ru_isrss=>0, :ru_minflt=>466, :ru_majflt=>0, :ru_nswap=>0, :ru_inblock=>0, :ru_oublock=>0, :ru_msgsnd=>0, :ru_msgrcv=>0, :ru_nsignals=>0, :ru_nvcsw=>4, :ru_nivcsw=>9}
     ```
 
+- Resource::Rusage#ru_utime
+
+    ```ruby
+    # TODO: add other rusage method like ru_stime
+    Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime #=> 0.002736
+    ```
+
 ## License
 under the MIT License:
 

--- a/src/mrb_resource.c
+++ b/src/mrb_resource.c
@@ -29,12 +29,12 @@
 #define SET_MRB_KEY_RUSAGE_MEMBER2(hash, rusage, member)                                                               \
   mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_cstr(mrb, #member)), mrb_float_value(mrb, rusage.member));
 
-typedef struct mrb_resource_ctx {
+typedef struct mrb_rusage_ctx {
   struct rusage *ru;
-} mrb_resource_ctx;
+} mrb_rusage_ctx;
 
-static const struct mrb_data_type mrb_resource_ctx_type = {
-    "mrb_resource_ctx_type", mrb_free,
+static const struct mrb_data_type mrb_rusage_ctx_type = {
+    "mrb_rusage_ctx_type", mrb_free,
 };
 
 static void mrb_resource_rusage_inner(mrb_state *mrb, struct rusage *ru, mrb_int who)
@@ -50,18 +50,18 @@ static mrb_value mrb_resource_getrusage_init(mrb_state *mrb, mrb_value self)
 {
   struct rusage ru;
   mrb_int who;
-  mrb_resource_ctx *ctx;
+  mrb_rusage_ctx *ctx;
 
   mrb_get_args(mrb, "i", &who);
   mrb_resource_rusage_inner(mrb, &ru, who);
 
-  ctx = (mrb_resource_ctx *)DATA_PTR(self);
+  ctx = (mrb_rusage_ctx *)DATA_PTR(self);
   if (ctx) {
     mrb_free(mrb, ctx);
   }
 
-  DATA_TYPE(self) = &mrb_resource_ctx_type;
-  ctx = (mrb_resource_ctx *)mrb_malloc(mrb, sizeof(mrb_resource_ctx));
+  DATA_TYPE(self) = &mrb_rusage_ctx_type;
+  ctx = (mrb_rusage_ctx *)mrb_malloc(mrb, sizeof(mrb_rusage_ctx));
   ctx->ru = &ru;
 
   DATA_PTR(self) = ctx;
@@ -71,7 +71,7 @@ static mrb_value mrb_resource_getrusage_init(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_resource_getrusage_ru_utime(mrb_state *mrb, mrb_value self)
 {
-  mrb_resource_ctx *ctx = (mrb_resource_ctx *)DATA_PTR(self);
+  mrb_rusage_ctx *ctx = (mrb_rusage_ctx *)DATA_PTR(self);
 
   return mrb_float_value(mrb, (double)ctx->ru->ru_utime.tv_sec + (double)ctx->ru->ru_utime.tv_usec / 1e6);
 }

--- a/src/mrb_resource.c
+++ b/src/mrb_resource.c
@@ -14,9 +14,9 @@
 
 #include "mruby.h"
 #include "mruby/array.h"
-#include "mruby/hash.h"
-#include "mruby/data.h"
 #include "mruby/class.h"
+#include "mruby/data.h"
+#include "mruby/hash.h"
 
 #include "mrb_resource.h"
 

--- a/src/mrb_resource.c
+++ b/src/mrb_resource.c
@@ -15,6 +15,8 @@
 #include "mruby.h"
 #include "mruby/array.h"
 #include "mruby/hash.h"
+#include "mruby/data.h"
+#include "mruby/class.h"
 
 #include "mrb_resource.h"
 
@@ -27,20 +29,63 @@
 #define SET_MRB_KEY_RUSAGE_MEMBER2(hash, rusage, member)                                                               \
   mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_cstr(mrb, #member)), mrb_float_value(mrb, rusage.member));
 
+typedef struct mrb_resource_ctx {
+  struct rusage *ru;
+} mrb_resource_ctx;
+
+static const struct mrb_data_type mrb_resource_ctx_type = {
+    "mrb_resource_ctx_type", mrb_free,
+};
+
+static void mrb_resource_rusage_inner(mrb_state *mrb, struct rusage *ru, mrb_int who)
+{
+  int ret = getrusage(who, ru);
+
+  if (ret < 0) {
+    mrb_raisef(mrb, E_RUNTIME_ERROR, "%S:%S\n", mrb_fixnum_value(errno), mrb_str_new_cstr(mrb, strerror(errno)));
+  }
+}
+
+static mrb_value mrb_resource_getrusage_init(mrb_state *mrb, mrb_value self)
+{
+  struct rusage ru;
+  mrb_int who;
+  mrb_resource_ctx *ctx;
+
+  mrb_get_args(mrb, "i", &who);
+  mrb_resource_rusage_inner(mrb, &ru, who);
+
+  ctx = (mrb_resource_ctx *)DATA_PTR(self);
+  if (ctx) {
+    mrb_free(mrb, ctx);
+  }
+
+  DATA_TYPE(self) = &mrb_resource_ctx_type;
+  ctx = (mrb_resource_ctx *)mrb_malloc(mrb, sizeof(mrb_resource_ctx));
+  ctx->ru = &ru;
+
+  DATA_PTR(self) = ctx;
+
+  return self;
+}
+
+static mrb_value mrb_resource_getrusage_ru_utime(mrb_state *mrb, mrb_value self)
+{
+  mrb_resource_ctx *ctx = (mrb_resource_ctx *)DATA_PTR(self);
+
+  return mrb_float_value(mrb, (double)ctx->ru->ru_utime.tv_sec + (double)ctx->ru->ru_utime.tv_usec / 1e6);
+}
+
 static mrb_value mrb_resource_getrusage(mrb_state *mrb, mrb_value self)
 {
 
   struct rusage ru;
-  int ret = 0;
   mrb_value r;
 
   mrb_int who;
   mrb_get_args(mrb, "i", &who);
 
-  ret = getrusage(who, &ru);
-  if (ret < 0) {
-    mrb_raisef(mrb, E_RUNTIME_ERROR, "%S:%S\n", mrb_fixnum_value(errno), mrb_str_new_cstr(mrb, strerror(errno)));
-  }
+  mrb_resource_rusage_inner(mrb, &ru, who);
 
   r = mrb_hash_new(mrb);
   SET_MRB_KEY_RUSAGE_MEMBER1(r, ru, ru_utime);
@@ -114,7 +159,7 @@ static mrb_value mrb_resource_setrlimit(mrb_state *mrb, mrb_value self)
 void mrb_mruby_resource_gem_init(mrb_state *mrb)
 {
 
-  struct RClass *resource;
+  struct RClass *resource, *rusage;
   resource = mrb_define_module(mrb, "Resource");
 
 #ifdef RLIMIT_AS
@@ -190,6 +235,10 @@ void mrb_mruby_resource_gem_init(mrb_state *mrb)
   mrb_define_module_function(mrb, resource, "getrusage", mrb_resource_getrusage, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, resource, "getrlimit", mrb_resource_getrlimit, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, resource, "setrlimit", mrb_resource_setrlimit, MRB_ARGS_ARG(2, 1));
+
+  rusage = mrb_define_class_under(mrb, resource, "Rusage", mrb->object_class);
+  mrb_define_method(mrb, rusage, "initialize", mrb_resource_getrusage_init, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, rusage, "ru_utime", mrb_resource_getrusage_ru_utime, MRB_ARGS_NONE());
   DONE;
 }
 

--- a/src/mrb_resource.c
+++ b/src/mrb_resource.c
@@ -237,6 +237,7 @@ void mrb_mruby_resource_gem_init(mrb_state *mrb)
   mrb_define_module_function(mrb, resource, "setrlimit", mrb_resource_setrlimit, MRB_ARGS_ARG(2, 1));
 
   rusage = mrb_define_class_under(mrb, resource, "Rusage", mrb->object_class);
+  MRB_SET_INSTANCE_TT(rusage, MRB_TT_DATA);
   mrb_define_method(mrb, rusage, "initialize", mrb_resource_getrusage_init, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, rusage, "ru_utime", mrb_resource_getrusage_ru_utime, MRB_ARGS_NONE());
   DONE;

--- a/test/bench.rb
+++ b/test/bench.rb
@@ -1,0 +1,17 @@
+##
+## Resource Test
+##
+
+assert("Resource::Rusage#ru_utime vs Resource.getrusage") do
+  a = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime]
+  100000.times { Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] }
+  b = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] 
+  c = b - a
+
+  a = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime]
+  100000.times { Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime }
+  b = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
+  d = b - a
+
+  assert_true(d < c)
+end

--- a/test/mrb_resource.rb
+++ b/test/mrb_resource.rb
@@ -3,17 +3,11 @@
 ##
 
 assert("Resource.getrusage") do
-  before = Resource.getrusage Resource::RUSAGE_SELF
-  10000.times {}
-  after = Resource.getrusage Resource::RUSAGE_SELF
-  assert_true((after[:ru_utime] - before[:ru_utime]) > 0)
+  assert_true(Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] > 0)
 end
 
 assert("Resource::Rusage#ru_utime") do
-  before_utime = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
-  10000.times {}
-  after_utime = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
-  assert_true((after_utime - before_utime) > 0)
+  assert_true(Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime > 0)
 end
 
 # TODO: add other tests

--- a/test/mrb_resource.rb
+++ b/test/mrb_resource.rb
@@ -9,4 +9,11 @@ assert("Resource.getrusage") do
   assert_true((after[:ru_utime] - before[:ru_utime]) > 0)
 end
 
+assert("Resource::Rusage#ru_utime") do
+  before_utime = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
+  1000.times {}
+  after_utime = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
+  assert_true((after_utime - before_utime) > 0)
+end
+
 # TODO: add other tests

--- a/test/mrb_resource.rb
+++ b/test/mrb_resource.rb
@@ -4,14 +4,14 @@
 
 assert("Resource.getrusage") do
   before = Resource.getrusage Resource::RUSAGE_SELF
-  1000.times {}
+  10000.times {}
   after = Resource.getrusage Resource::RUSAGE_SELF
   assert_true((after[:ru_utime] - before[:ru_utime]) > 0)
 end
 
 assert("Resource::Rusage#ru_utime") do
   before_utime = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
-  1000.times {}
+  10000.times {}
   after_utime = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
   assert_true((after_utime - before_utime) > 0)
 end

--- a/test/mrb_resource.rb
+++ b/test/mrb_resource.rb
@@ -16,4 +16,17 @@ assert("Resource::Rusage#ru_utime") do
   assert_true((after_utime - before_utime) > 0)
 end
 
+assert("Resource::Rusage#ru_utime vs Resource.getrusage") do
+  a = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime]
+  100000.times { Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] }
+  b = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] 
+  c = b - a
+
+  a = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime]
+  100000.times { Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime }
+  b = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
+  d = b - a
+
+  assert_true(d < c)
+end
 # TODO: add other tests

--- a/test/mrb_resource.rb
+++ b/test/mrb_resource.rb
@@ -16,17 +16,4 @@ assert("Resource::Rusage#ru_utime") do
   assert_true((after_utime - before_utime) > 0)
 end
 
-assert("Resource::Rusage#ru_utime vs Resource.getrusage") do
-  a = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime]
-  100000.times { Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] }
-  b = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] 
-  c = b - a
-
-  a = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime]
-  100000.times { Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime }
-  b = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime
-  d = b - a
-
-  assert_true(d < c)
-end
 # TODO: add other tests


### PR DESCRIPTION
rusageの中の使いたいデータだけをとりたい、あるいは、ミドルウェアの中で処理させる場合は、ハッシュで返すよりも構造体をインスタンスに保存しておいて、指定のものだけをオブジェクト化したほうが効率よく性能が早いので、`Resource::Rusage#ru_utime`を追加しました。今後はこれ相当のメソッドを複数追加することになりそうですが、一旦`ru_time`とその枠組みだけを追加しました。

以下ベンチ。
- 既存のメソッド

``` ruby
a = nil
100000.times { a = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] }
p a
```

```
$ ./mruby/bin/mruby a.rb 
0.13917
```
- 今回追加したメソッド

``` ruby
a = nil
#100000.times { a = Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] }
100000.times { a = Resource::Rusage.new(Resource::RUSAGE_SELF).ru_utime }
p a
```

```
$ ./mruby/bin/mruby a.rb 
0.049195
```

ru_utimeだけがほしい場合は、3倍以上効率がよさそうです。
