### PR TITLE
Support prlimit(2) when available

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,7 @@
 MRuby::Gem::Specification.new('mruby-resource') do |spec|
   spec.license = 'MIT'
   spec.authors = 'SOGO Haraguchi'
+
+  spec.add_test_dependency 'mruby-process'
+  spec.add_test_dependency 'mruby-exec', github: 'haconiwa/mruby-exec'
 end

--- a/src/mrb_resource.c
+++ b/src/mrb_resource.c
@@ -108,6 +108,16 @@ static mrb_value mrb_resource_getrusage(mrb_state *mrb, mrb_value self)
   return r;
 }
 
+static mrb_value mrb_resource_make_rlarray(mrb_state *mrb, const struct rlimit rl)
+{
+  mrb_value array;
+  array = mrb_ary_new(mrb);
+  mrb_ary_push(mrb, array, mrb_float_value(mrb, rl.rlim_cur));
+  mrb_ary_push(mrb, array, mrb_float_value(mrb, rl.rlim_max));
+
+  return array;
+}
+
 static mrb_value mrb_resource_getrlimit(mrb_state *mrb, mrb_value self)
 {
 
@@ -123,11 +133,7 @@ static mrb_value mrb_resource_getrlimit(mrb_state *mrb, mrb_value self)
     mrb_raisef(mrb, E_RUNTIME_ERROR, "%S:%S\n", mrb_fixnum_value(errno), mrb_str_new_cstr(mrb, strerror(errno)));
   }
 
-  array = mrb_ary_new(mrb);
-  mrb_ary_push(mrb, array, mrb_float_value(mrb, rl.rlim_cur));
-  mrb_ary_push(mrb, array, mrb_float_value(mrb, rl.rlim_max));
-
-  return array;
+  return mrb_resource_make_rlarray(mrb, rl);
 }
 
 static mrb_value mrb_resource_setrlimit(mrb_state *mrb, mrb_value self)

--- a/test/mrb_resource.rb
+++ b/test/mrb_resource.rb
@@ -20,6 +20,34 @@ assert("Resource.setrlimit") do
   assert_equal h, h2
 end
 
+assert("Resource.getprlimit") do
+  pid = fork do
+    exec "/bin/bash", "-c", "sleep 60"
+  end
+
+  s, h = Resource.getprlimit(pid, Resource::RLIMIT_NOFILE)
+  assert_true s >= 0
+  assert_true h >= s
+  Process.kill :TERM, pid
+end
+
+assert("Resource.setprlimit") do
+  pid = fork do
+    exec "/bin/bash", "-c", "sleep 60"
+  end
+
+  s, h = Resource.getprlimit(pid, Resource::RLIMIT_NOFILE)
+  s -= 1
+  h -= 1
+
+  Resource.setprlimit(pid, Resource::RLIMIT_NOFILE, s, h)
+  s2, h2 = Resource.getprlimit(pid, Resource::RLIMIT_NOFILE)
+
+  assert_equal s, s2
+  assert_equal h, h2
+  Process.kill :TERM, pid
+end
+
 assert("Resource.getrusage") do
   assert_true(Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] > 0)
 end

--- a/test/mrb_resource.rb
+++ b/test/mrb_resource.rb
@@ -2,6 +2,24 @@
 ## Resource Test
 ##
 
+assert("Resource.getrlimit") do
+  s, h = Resource.getrlimit(Resource::RLIMIT_NOFILE)
+  assert_true s >= 0
+  assert_true h >= s
+end
+
+assert("Resource.setrlimit") do
+  s, h = Resource.getrlimit(Resource::RLIMIT_NOFILE)
+  s -= 1
+  h -= 1
+
+  Resource.setrlimit(Resource::RLIMIT_NOFILE, s, h)
+  s2, h2 = Resource.getrlimit(Resource::RLIMIT_NOFILE)
+
+  assert_equal s, s2
+  assert_equal h, h2
+end
+
 assert("Resource.getrusage") do
   assert_true(Resource.getrusage(Resource::RUSAGE_SELF)[:ru_utime] > 0)
 end


### PR DESCRIPTION
Usage:

```ruby
res = Resource.getprlimit(pid, Resource::RLIMIT_NOFILE)
#=> [1024, 65536]

res = Resource.setprlimit(pid, Resource::RLIMIT_NOFILE, 4096, 65536)
#=> nil when success
```

It is activated with using linux kernel >= `2.6.36`, ref https://linuxjm.osdn.jp/html/LDP_man-pages/man2/setrlimit.2.html